### PR TITLE
Ignore unresolvable modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,11 @@ function getModuleConfig(options, importSource) {
 		return options.modules[importSource];
 	}
 
-	return options.modules[bareName(importSource)];
+	try {
+		return options.modules[bareName(importSource)];
+	} catch (error) {
+		return null;
+	}
 }
 
 const majorDeleteError = 'html-minifier deleted something major, cannot proceed.';

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ html`
 `;
 ```
 
-Using the .babelrc shown in [#Usage] produces the following output:
+Using the .babelrc shown in [usage](#Usage) produces the following output:
 
 ```js
 import choo from 'choo/html';

--- a/test.js
+++ b/test.js
@@ -344,3 +344,13 @@ test('tolerate built-in modules', t => babelTest(t, {
 		}
 	}
 }));
+
+test('ignore unknown modules', t => babelTest(t, {
+	source: 'const unknown = require(\'unknown-module\');',
+	result: 'const unknown = require(\'unknown-module\');',
+	pluginOptions: {
+		modules: {
+			'choo/html': [null]
+		}
+	}
+}));


### PR DESCRIPTION
Previously an unresolvable module would cause an exception to be throw.
This caused problems for custom resolvers.  I had considered using an
option for this but really a linter is the correct tool to check for
invalid imports.

Fixes #4