### PR TITLE
Fix processing of JavaScript escape codes inside html templates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = babel => {
 		}
 
 		const {node} = template;
-		const quasis = node.quasis.map(quasi => quasi.value.cooked);
+		const quasis = node.quasis.map(quasi => quasi.value.raw);
 
 		const placeholder = uniqueId(quasis.join(''));
 		const parts = htmlMinifier
@@ -77,9 +77,8 @@ module.exports = babel => {
 		if (parts.length !== quasis.length) {
 			throw new Error(majorDeleteError);
 		}
-		parts.forEach((value, i) => {
-			const args = {cooked: value, raw: value};
-			template.get('quasis')[i].replaceWith(t.templateElement(args, i === parts.length - 1));
+		parts.forEach((raw, i) => {
+			template.get('quasis')[i].replaceWith(t.templateElement({raw}, i === parts.length - 1));
 		});
 	}
 

--- a/test.js
+++ b/test.js
@@ -535,3 +535,14 @@ test('ignore this outside class', t => babelTest(t, {
 	pluginOptions: {
 	}
 }));
+
+test('css unicode with double-backslash', t => babelTest(t, {
+	source: 'import{html}from"lit-html";html`<style>div::before{content:"\\2003"}</style><div></div>`;',
+	result: 'import{html}from"lit-html";html`<style>div::before{content:"\\2003"}</style><div></div>`;',
+	pluginOptions: {
+		modules: {
+			'lit-html': ['html']
+		},
+		htmlMinifier: defaultHtmlMin
+	}
+}));


### PR DESCRIPTION
We were providing quasi.value.cooked to the html-minifier which was
causing problems for CSS escape sequences such as `content: "\\2003"`.
Switch to using quasi.value.raw.

Fixes #8