### PR TITLE
Use hack to support use of @babel/plugin-transform-template-literals.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.1.6",
+		"@babel/plugin-transform-template-literals": "^7.2.0",
 		"@polymer/lit-element": "^0.6.3",
 		"ava": "^1.0.0-beta.8",
 		"hyperhtml-element": "^3.1.0",


### PR DESCRIPTION
This passes the `raw` quasis to a secondary babel processor so we can
get the `cooked` quasis.  This is required to support situations where
additional plugins might need the cooked value, such as
@babel/plugin-transform-template-literals.

Fixes #10
Refs babel/babel#9242