### PR TITLE
fix: don't crash when a class has javascript mixins

### DIFF
--- a/fixtures/import-hyperhtml-star-with-mixin-source.js
+++ b/fixtures/import-hyperhtml-star-with-mixin-source.js
@@ -1,0 +1,12 @@
+import * as elements from 'hyperhtml-element';
+
+const myMixin = baseClass => class extends baseClass {
+
+};
+
+export class ele extends myMixin(elements.base) {
+	render() {
+		this.html`<div >test</div>`;
+		this.nothtml`<div >test</div>`;
+	}
+}

--- a/fixtures/import-member-class-of-star-export-with-mixin.js
+++ b/fixtures/import-member-class-of-star-export-with-mixin.js
@@ -1,0 +1,12 @@
+import * as elements from 'hyperhtml-element';
+
+const myMixin = baseClass => class extends baseClass {
+
+};
+
+export class ele extends myMixin(elements.base) {
+	render() {
+		this.html`<div >test</div>`;
+		this.nothtml`<div >test</div>`;
+	}
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,7 +118,7 @@ function handleMember(path, state) {
 			handleSimple(path, state, cls.scope.getBinding(superClass.name),
 				item => item.options.member === propName
 			);
-		} else {
+		} else if (superClass.object && superClass.object.name) {
 			handleStar(path, state, superClass.object.name,
 				opt => opt.member === propName && superClass.property.name === opt.name && opt.type === 'member'
 			);

--- a/test/test.js
+++ b/test/test.js
@@ -242,6 +242,7 @@ test('import member class of named export from non-matching module', fileTest, '
 test('import member class of unwanted named export', fileTest, 'import-hyperhtml-named', true, wrongHyperConfig);
 
 test('import member class of star export', fileTest, 'import-hyperhtml-star', null, namedHyperConfig);
+test('import member class of star export with mixin', fileTest, 'import-hyperhtml-star-with-mixin', null, namedHyperConfig);
 test('import member class of star export from non-matching module', fileTest, 'import-hyperhtml-star', true, namedWrongMemberConfig);
 
 test('ignore this outside class', fileTest, null, true);


### PR DESCRIPTION
Fixes https://github.com/cfware/babel-plugin-template-html-minifier/issues/32

Now we're just ignoring classes with mixins, if you're using star import. It can probably be improved by correctly parsing the mixins as well but at least now it doesn't crash the plugin when there is a mixin involved.