### PR TITLE
Make error handling behavior configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ A list of module names or import paths where tags are imported from.  The values
 the arrays refers to the export names, not the import names.  `null` refers to the
 default export.
 
+### failOnError
+
+Determines whether an error should be thrown when minification failed. defaults to true.
+
+Minification can fail when using invalid syntax or comments within bindings. Especially
+when using css with bindings minification can fail. When `failOnError` is true, this
+plugin throws an error and your build will stop from proceeding. When it is false
+the minification is canceled and the template is left unminified.
+
+### logOnError
+Determines whether failure to minify a template should be logged in case of an error.
+Defaults to true.
+
 ```js
 import choo from 'choo/html';
 import * as lit from 'lit-html';

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,21 +67,34 @@ function minify(path, state, bindingOptions) {
 
 	const placeholder = uniqueId(quasis.join(''));
 	const tags = encapsulationGetTags(bindingOptions);
+	let parts;
 
-	const minified = htmlMinifier.minify(tags.opening + quasis.join(placeholder) + tags.closing, state.opts.htmlMinifier);
-	if (!minified.startsWith(tags.opening) || !minified.endsWith(tags.closing)) {
-		throw path.buildCodeFrameError(majorDeleteError);
+	try {
+		const minified = htmlMinifier.minify(tags.opening + quasis.join(placeholder) + tags.closing, state.opts.htmlMinifier);
+		if (!minified.startsWith(tags.opening) || !minified.endsWith(tags.closing)) {
+			throw path.buildCodeFrameError(majorDeleteError);
+		}
+
+		const minifiedParts = minified.slice(tags.opening.length, -tags.closing.length || undefined).split(placeholder);
+		if (minifiedParts.length !== quasis.length) {
+			throw path.buildCodeFrameError(majorDeleteError);
+		}
+
+		parts = minifiedParts;
+	} catch (error) {
+		if (state.failOnError) {
+			throw error;
+		} else if (state.logOnError) {
+			console.error(error.message);
+		}
 	}
 
-	const parts = minified.slice(tags.opening.length, -tags.closing.length || undefined).split(placeholder);
-	if (parts.length !== quasis.length) {
-		throw path.buildCodeFrameError(majorDeleteError);
+	if (parts) {
+		parts.forEach((raw, i) => {
+			const args = cookRawQuasi(state.babel, raw);
+			template.get('quasis')[i].replaceWith(t.templateElement(args, i === parts.length - 1));
+		});
 	}
-
-	parts.forEach((raw, i) => {
-		const args = cookRawQuasi(state.babel, raw);
-		template.get('quasis')[i].replaceWith(t.templateElement(args, i === parts.length - 1));
-	});
 }
 
 function handleStar(path, state, objName, optionsFilter) {
@@ -137,6 +150,8 @@ module.exports = babel => {
 			Program: {
 				enter() {
 					this.moduleConfigs = normalizeModulesConfig(this.opts.modules);
+					this.failOnError = this.opts.failOnError !== false;
+					this.logOnError = this.opts.logOnError !== false;
 					this.babel = babel;
 					this.bindings = [];
 				}


### PR DESCRIPTION
I'm working on https://github.com/cfware/babel-plugin-template-html-minifier/issues/30, but putting this in as a separate PR.

This makes the error handling behavior configurable, which is useful especially when dealing with CSS but also with some types of HTML and bindings in comments.

You can turn on minification and comment removal, in the case of some malformed template or css you get a notification but it doesn't crash the built. If the error is from code not under your control you can create an issue at the responsible project, but it doesn't block you from moving on.

Personally I'd say `failOnError` should be false by default, what do you think? It would be a breaking change, so many it's good to do that along with other breaking changes.